### PR TITLE
change action as symbol

### DIFF
--- a/src/routes.lisp
+++ b/src/routes.lisp
@@ -34,7 +34,9 @@
   (etypecase rule
     ((or function symbol) (make-controller rule))
     (string
-     (make-controller (symbol-function (intern-rule rule *controllers-directory*))))))
+     (let ((action (intern-rule rule *controllers-directory*)))
+       (assert (symbolp action))
+       (make-controller action)))))
 
 (defvar *package-routes* (make-hash-table :test 'eq))
 


### PR DESCRIPTION
routeが評価されたときにactionに対応するsymbol-functionが紐づけられてしまい
controller側の関数を再定義してもactionの関数自体は変更されません
actionの値はsymbol-functionではなくsymbolにすることで間接参照の形になるのでこの問題は無くなります