### PR TITLE
Fix to parse port number

### DIFF
--- a/src/cli/server.lisp
+++ b/src/cli/server.lisp
@@ -40,6 +40,12 @@ OPTIONS
     (when args
       (invalid-arguments (format nil "~&Extra arguments: ~{'~A'~^, ~}~%" args)))
 
+    (when (assoc :port options)
+      (let ((port-number (parse-integer (cdr (assoc :port options)) :junk-allowed t)))
+        (if (and port-number (> port-number 0))
+            (setf (cdr (assoc :port options)) port-number)
+            (invalid-arguments (format nil "~&Port number must be positive number.~%" args)))))
+
     (let ((app-file (merge-pathnames #P"app.lisp" *default-pathname-defaults*)))
       (unless (uiop:file-exists-p app-file)
         (error 'simple-task-error


### PR DESCRIPTION
Currently, when starting the server with the utopian command, if a port number is specified, the port number is passed to crackup as a string, resulting in a type error.
I have added code to parse the port number to subcommand.

```
~/blog $ .qlot/bin/utopian server --port 5061
...
Hunchentoot server is going to start.
Listening on 127.0.0.1:5061.
Unhandled USOCKET:UNKNOWN-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                             {100E768173}>:
  The condition The value of SB-BSD-SOCKETS::ADDRESS is (#(127 0 0 1)
                                                         "5061"), which is not of type (OR
                                                                                        NULL
                                                                                        (CONS
                                                                                         SEQUENCE
                                                                                         (CONS
                                                                                          (UNSIGNED-BYTE
                                                                                           16)))). occurred with errno: 0.

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {100E768173}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<USOCKET:UNKNOWN-ERROR {1005088823}> #<unused argument> :QUIT T)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<USOCKET:UNKNOWN-ERROR {1005088823}>)
2: (INVOKE-DEBUGGER #<USOCKET:UNKNOWN-ERROR {1005088823}>)
3: (ERROR #<USOCKET:UNKNOWN-ERROR {1005088823}>)
4: (USOCKET:SOCKET-LISTEN "127.0.0.1" "5061" :REUSEADDRESS T :REUSE-ADDRESS NIL :BACKLOG 50 :ELEMENT-TYPE (UNSIGNED-BYTE 8))
5: ((:METHOD HUNCHENTOOT:START-LISTENING (HUNCHENTOOT:ACCEPTOR)) #<CLACK.HANDLER.HUNCHENTOOT::CLACK-ACCEPTOR (host 127.0.0.1, port 5061)>) [fast-method]
6: ((SB-PCL::EMF HUNCHENTOOT:START-LISTENING) #<unused argument> #<unused argument> #<CLACK.HANDLER.HUNCHENTOOT::CLACK-ACCEPTOR (host 127.0.0.1, port 5061)>)
7: ((:METHOD HUNCHENTOOT:START (HUNCHENTOOT:ACCEPTOR)) #<CLACK.HANDLER.HUNCHENTOOT::CLACK-ACCEPTOR (host 127.0.0.1, port 5061)>) [fast-method]
8: (CLACK.HANDLER.HUNCHENTOOT:RUN #<FUNCTION (LAMBDA (LACK.MIDDLEWARE.BACKTRACE::ENV) :IN "/home/wiz/.roswell/local-projects/masatoi/blog/.qlot/dists/lack/software/lack-ref-156ef010d5a90e629107b44661221b26b507d7ef/src/middleware/backtrace.lisp") {1002B2EB4B}> :ALLOW-OTHER-KEYS T :PORT "5061" :DEBUG T :USE-THREAD NIL)
9: (CLACK.HANDLER:RUN #<FUNCTION (LAMBDA (LACK.MIDDLEWARE.BACKTRACE::ENV) :IN "/home/wiz/.roswell/local-projects/masatoi/blog/.qlot/dists/lack/software/lack-ref-156ef010d5a90e629107b44661221b26b507d7ef/src/middleware/backtrace.lisp") {1002B2EB4B}> :HUNCHENTOOT :PORT "5061" :DEBUG T :USE-THREAD NIL)
10: (CLACK:CLACKUP #P"/home/wiz/.roswell/local-projects/masatoi/blog/app.lisp" :USE-THREAD NIL :PORT "5061")
11: (MAIN "server" "--port" "5061")
12: (SB-INT:SIMPLE-EVAL-IN-LEXENV (APPLY (QUOTE MAIN) ROSWELL:*ARGV*) #<NULL-LEXENV>)
13: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) #<NULL-LEXENV>)
14: (SB-EXT:EVAL-TLF (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL NIL)
15: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL)
16: (SB-INT:LOAD-AS-SOURCE #<CONCATENATED-STREAM :STREAMS NIL {1008304073}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
17: ((LABELS SB-FASL::LOAD-STREAM-1 :IN LOAD) #<CONCATENATED-STREAM :STREAMS NIL {1008304073}> NIL)
18: (SB-FASL::CALL-WITH-LOAD-BINDINGS #<FUNCTION (LABELS SB-FASL::LOAD-STREAM-1 :IN LOAD) {7F3667FFF69B}> #<CONCATENATED-STREAM :STREAMS NIL {1008304073}> NIL #<CONCATENATED-STREAM :STREAMS NIL {1008304073}>)
19: (LOAD #<CONCATENATED-STREAM :STREAMS NIL {1008304073}> :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
20: ((FLET ROSWELL::BODY :IN ROSWELL:SCRIPT) #<SB-SYS:FD-STREAM for "file /home/wiz/.roswell/local-projects/masatoi/blog/.qlot/bin/../dists/utopian/software/utopian-ref-c6ad73d5a9bba245ad7b747e7764c94e3ea0ba23/roswell/utopian.ros" {10082FB3D3}>)
21: (ROSWELL:SCRIPT ".qlot/bin/../dists/utopian/software/utopian-ref-c6ad73d5a9bba245ad7b747e7764c94e3ea0ba23/roswell/utopian.ros" "server" "--port" "5061")
22: (ROSWELL:RUN ((:EVAL "(ros:quicklisp)") (:SCRIPT ".qlot/bin/../dists/utopian/software/utopian-ref-c6ad73d5a9bba245ad7b747e7764c94e3ea0ba23/roswell/utopian.ros" "server" "--port" "5061") (:QUIT NIL)))
23: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:RUN (QUOTE ((:EVAL "(ros:quicklisp)") (:SCRIPT ".qlot/bin/../dists/utopian/software/utopian-ref-c6ad73d5a9bba245ad7b747e7764c94e3ea0ba23/roswell/utopian.ros" "server" "--port" "5061") (:QUIT NIL)))) #<NULL-LEXENV>)
24: (EVAL (ROSWELL:RUN (QUOTE ((:EVAL "(ros:quicklisp)") (:SCRIPT ".qlot/bin/../dists/utopian/software/utopian-ref-c6ad73d5a9bba245ad7b747e7764c94e3ea0ba23/roswell/utopian.ros" "server" "--port" "5061") (:QUIT NIL)))))
25: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"/home/wiz/etc/roswell/init.lisp\"))") (:EVAL . "(ros:run '((:eval\"(ros:quicklisp)\")(:script \".qlot/bin/../dists/utopian/software/utopian-ref-c6ad73d5a9bba245ad7b747e7764c94e3ea0ba23/roswell/utopian.ros\"\"server\"\"--port\"\"5061\")(:quit ())))")))
26: (SB-IMPL::TOPLEVEL-INIT)
27: ((FLET SB-UNIX::BODY :IN SB-IMPL::START-LISP))
28: ((FLET "WITHOUT-INTERRUPTS-BODY-3" :IN SB-IMPL::START-LISP))
29: (SB-IMPL::START-LISP)
```