### PR TITLE
Fix to convert to integer if port is a string

### DIFF
--- a/src/tasks.lisp
+++ b/src/tasks.lisp
@@ -11,8 +11,7 @@
            #:use-value))
 (in-package #:utopian/tasks)
 
-(defun server (app-file &rest args &key address port)
-  (declare (ignore address port))
+(defun server (app-file &key address port)
   (check-type app-file pathname)
   (unless (probe-file app-file)
     (error 'file-not-found :file app-file))
@@ -28,8 +27,9 @@
         #-quicklisp
         (asdf:missing-component (e)
           (error 'system-not-found :system (asdf/find-component:missing-requires e))))))
-  (apply #'clack:clackup app-file :use-thread nil
-         args))
+  (clack:clackup app-file :use-thread nil
+                 :port (if (stringp port) (parse-integer port) port)
+                 :address address))
 
 (defun read-new-value (name &optional default)
   (format t "~A~@[ [~A]~]: " name (if (equal default "") nil default))


### PR DESCRIPTION
I was getting an error when I started the server with the following command.

```
$ utopian server --address 0.0.0.0 --port 5000

...

Hunchentoot server is going to start.
Listening on 0.0.0.0:5000.
Unhandled USOCKET:UNKNOWN-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                             {10015601F3}>:
  The condition The value of SB-BSD-SOCKETS::ADDRESS is (#(0 0 0 0)
                                                         "5000"), which is not of type (OR
                                                                                        NULL
                                                                                        (CONS
                                                                                         SEQUENCE
                                                                                         (CONS
                                                                                          (UNSIGNED-BYTE
                                                                                           16)))). occurred with errno: 0.
```

This PR is a fix for that problem.